### PR TITLE
Compatibility with django-taggit 0.9.0+

### DIFF
--- a/cab/models.py
+++ b/cab/models.py
@@ -57,7 +57,7 @@ class SnippetManager(models.Manager):
         return self.all().order_by('-bookmark_count')
 
     def matches_tag(self, tag):
-        return self.filter(tags__in=[tag])
+        return self.filter(tags__name__in=[tag])
 
 DJANGO_VERSIONS = (
     (1.2, '1.2'),


### PR DESCRIPTION
The Taggit filtering API has changed as of version 0.9.0. From the Taggit changelog (http://packages.python.org/django-taggit/changelog.html):

_Backwards incompatible_ Filtering on tags is no longer `filter(tags__in=["foo"])`, it is written `filter(tags__name__in=["foo"])`.
