### PR TITLE
EditSnippets template doesn't render tags-errors

### DIFF
--- a/cab/templates/cab/edit_snippet.html
+++ b/cab/templates/cab/edit_snippet.html
@@ -18,7 +18,7 @@
     <dd>{{ form.language }}{% if form.language.errors %}<span class="error">&nbsp;&nbsp;{{ form.language.errors|join:", " }}</span>{% endif %}</dd>
     <dt><label for="id_django_version">Django version:</label></dt>
     <dd>{{ form.django_version }}{% if form.django_version.errors %}<span class="error">&nbsp;&nbsp;{{ form.django_version.errors|join:", " }}</span>{% endif %}</dd>
-    <dt><label for="id_tag_list">Tags: {% if form.tag_list.errors %}<span class="error">{{ form.tag_list.errors|join:", " }}</span>{% endif %} </label></dt>
+    <dt><label for="id_tag_list">Tags: {% if form.tags.errors %}<span class="error">{{ form.tags.errors|join:", " }}</span>{% endif %} </label></dt>
     <dd>{{ form.tags }}<br />Use commas between tag names, and hyphens for multiple words, like "tag1, tag2, tag3-with-long-name"</dd>
     <dd>{{ form.code }}</dd>
     <dt><label for="id_description">Description: {% if form.description.errors %}<span class="error">{{ form.description.errors|join:", " }}</span>{% endif %}</label></dt>


### PR DESCRIPTION
When editing a snippet errors with the tags-field are not displayed because the errors are still assumed to be attached to the tag_list field. This patch should fix this
