### PR TITLE
Correct minor typos on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ on port 8000.
 Docker 
 ------
 
-You may wish to use docker locally for prouction dependncy testing and development, here are the setup instructions::
+You may wish to use docker locally for production dependency testing and development, here are the setup instructions::
 
     $ docker-compose -f docker-compose.yml build
     $ docker-compose -f docker-compose.yml up -d 

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,4 @@
 -r base.txt
-flake8
-isort
+flake8==3.7.9
+isort==5.0.5
 Whoosh==2.7.4


### PR DESCRIPTION
This PR seeks to correct 2 very minor typos on the README.

`prouction` => `production`

`dependncy` => `dependency`