### PR TITLE
Add DEFAULT_AUTO_FIELD to settings

### DIFF
--- a/cab/tests/settings.py
+++ b/cab/tests/settings.py
@@ -68,3 +68,5 @@ CAB_VERSIONS = (
     ('0.0', '0.0'),
     ('1.1', '1.1'),
 )
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/djangosnippets/settings/base.py
+++ b/djangosnippets/settings/base.py
@@ -175,3 +175,5 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
     ]
 }
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'


### PR DESCRIPTION
There are several warnings related to DEFAULT_AUTO_FIELD missing in settings.py:

![Screenshot from 2021-06-05 13-24-22](https://user-images.githubusercontent.com/10715678/120890230-83985e80-c601-11eb-9ab1-6644ce34ce6c.png)

Adding the required setting to djangosnippets/settings/base.py and cab/tests/settings.py removes the warning.