### PR TITLE
:arrow_up: Add Django 3.1 + 3.2

### DIFF
--- a/djangosnippets/settings/base.py
+++ b/djangosnippets/settings/base.py
@@ -120,6 +120,8 @@ ACCOUNT_LOGOUT_REDIRECT_URL = "/"
 COMMENTS_APP = "cab"
 
 CAB_VERSIONS = (
+    ("3.2", "3.2"),
+    ("3.1", "3.1"),
     ("3.0", "3.0"),
     ("2.2", "2.2"),
     ("2.1", "2.1"),


### PR DESCRIPTION
This updates `CAB_VERSIONS` to include Django 3.1 and 3.2.