### PR TITLE
Don't show original snippet in related list

### DIFF
--- a/cab/templatetags/cab_tags.py
+++ b/cab/templatetags/cab_tags.py
@@ -35,7 +35,7 @@ def more_like_this(snippet, limit=None):
                 "language__name",
             )
         )
-        sqs = sqs.filter(language__name=snippet.language)
+        sqs = sqs.filter(language__name=snippet.language).exclude(pk=snippet.pk)
         if limit is not None:
             sqs = sqs[:limit]
     except AttributeError:


### PR DESCRIPTION
Currently, similar snippets shown below a snippet can (and will, often) include the currently shown snippet, which is a bit beside the point.