### PR TITLE
Fix htmx pagination

### DIFF
--- a/djangosnippets/templates/cab/partials/language_list.html
+++ b/djangosnippets/templates/cab/partials/language_list.html
@@ -10,6 +10,6 @@
   {% endfor %}
   </ul>
 
-  <p class="pagination">{% if has_previous %}<a href="?page={{ previous }}">&lt; Previous {{ results_per_page }}</a>{% endif %}&nbsp;&nbsp;{% if has_next %}<a href="?page={{ next }}">Next {{ results_per_page }} &gt;</a>{% endif %}</p>
+  <p class="pagination">{% if has_previous %}<a href="{% url 'cab_language_list' %}?page={{ previous }}">&lt; Previous {{ results_per_page }}</a>{% endif %}&nbsp;&nbsp;{% if has_next %}<a href="{% url 'cab_language_list' %}?page={{ next }}">Next {{ results_per_page }} &gt;</a>{% endif %}</p>
 
 </div>

--- a/djangosnippets/templates/cab/partials/most_bookmarked.html
+++ b/djangosnippets/templates/cab/partials/most_bookmarked.html
@@ -32,11 +32,11 @@
     </table>
     <p class="pagination">
       {% if has_previous %}
-        <a href="?page={{ previous }}{% if months %}&amp;months={{ months }}{% endif %}">&lt; Previous {{ results_per_page }}</a>
+        <a href="{% url 'cab_top_bookmarked' %}?page={{ previous }}{% if months %}&amp;months={{ months }}{% endif %}">&lt; Previous {{ results_per_page }}</a>
       {% endif %}
       &nbsp;&nbsp;
       {% if has_next %}
-        <a href="?page={{ next }}{% if months %}&amp;months={{ months }}{% endif %}">Next {{ results_per_page }} &gt;</a>
+        <a href="{% url 'cab_top_bookmarked' %}?page={{ next }}{% if months %}&amp;months={{ months }}{% endif %}">Next {{ results_per_page }} &gt;</a>
       {% endif %}
     </p>
     <p class="count">{{ hits }} snippet{{ hits|pluralize }} posted so far.</p>

--- a/djangosnippets/templates/cab/partials/tag_list.html
+++ b/djangosnippets/templates/cab/partials/tag_list.html
@@ -9,7 +9,7 @@
     {% endfor %}
     </ul>
 
-    <p class="pagination">{% if has_previous %}<a href="?page={{ previous }}">&lt; Previous {{ results_per_page }}</a>{% endif %}&nbsp;&nbsp;{% if has_next %}<a href="?page={{ next }}">Next {{ results_per_page }} &gt;</a>{% endif %}</p>
+    <p class="pagination">{% if has_previous %}<a href="{% url 'cab_top_tags' %}?page={{ previous }}">&lt; Previous {{ results_per_page }}</a>{% endif %}&nbsp;&nbsp;{% if has_next %}<a href="{% url 'cab_top_tags' %}?page={{ next }}">Next {{ results_per_page }} &gt;</a>{% endif %}</p>
   {% else %}
     <p>No tags have been used yet.</p>
   {% endif %}

--- a/djangosnippets/templates/cab/partials/top_rated.html
+++ b/djangosnippets/templates/cab/partials/top_rated.html
@@ -30,11 +30,11 @@
   </table>
   <p class="pagination">
     {% if has_previous %}
-      <a href="?page={{ previous }}{% if months %}&amp;months={{ months }}{% endif %}">&lt; Previous {{ results_per_page }}</a>
+      <a href="{% url 'cab_top_rated' %}?page={{ previous }}{% if months %}&amp;months={{ months }}{% endif %}">&lt; Previous {{ results_per_page }}</a>
     {% endif %}
     &nbsp;&nbsp;
     {% if has_next %}
-      <a href="?page={{ next }}{% if months %}&amp;months={{ months }}{% endif %}">Next {{ results_per_page }} &gt;</a>
+      <a href="{% url 'cab_top_rated' %}?page={{ next }}{% if months %}&amp;months={{ months }}{% endif %}">Next {{ results_per_page }} &gt;</a>
     {% endif %}
   </p>
   <p class="count">{{ hits }} snippet{{ hits|pluralize }} posted so far.</p>


### PR DESCRIPTION
When exploring popular snippets, the pagination appends the query string to the current URL.

Example:

1. Open https://djangosnippets.org
2. Click by tag (the URL is still https://djangosnippets.org)
3. The pagination link will append the query string to the current URL (https://djangosnippets.org/?page=2)