### PR TITLE
Fixed homepage partial template content and banner layout.

### DIFF
--- a/djangosnippets/static/scss/main.scss
+++ b/djangosnippets/static/scss/main.scss
@@ -301,7 +301,8 @@ body.search,
 body.bookmarks,
 body.user,
 body.snippet-list,
-body.with-sidebar {
+body.with-sidebar,
+body.frontpage {
     #content {
         @media #{$small-up} {
             @include grid-column(12);
@@ -324,7 +325,7 @@ body.with-sidebar {
 }
 
 body.frontpage {
-    #content, #sidebar {
+    #content.main, #sidebar.main {
         @media #{$small-up} {
             @include grid-column(12, $last-column: true);
         }

--- a/djangosnippets/templates/base.html
+++ b/djangosnippets/templates/base.html
@@ -59,11 +59,11 @@
 
   <div id="base-container">
   <h1>{% block content_header %}{% endblock %}</h1>
-  <div id="content">
+  <div id="content" class="main">
       {% block content %}
       {% endblock %}
   </div>
-  <div id="sidebar">
+  <div id="sidebar" class="main">
     {% block sidebar %}
     {% endblock %}
   </div>


### PR DESCRIPTION
Currently, the sections where partial templates are used on the website have a 1:1 layout ratio between the content and the sidebar.

<img width="1055" alt="Screenshot 2025-06-05 at 9 50 17 AM" src="https://github.com/user-attachments/assets/ca09f3f2-34c1-45fb-bbb3-e41a83d6de23" />

This layout feels a bit awkward. The content area, which contains relatively more information such as tables, should be larger than the sidebar.

On pages that are not rendered using partials, the table takes up 2/3 of the space, while the sidebar occupies 1/3.

<img width="1017" alt="Screenshot 2025-06-05 at 9 52 22 AM" src="https://github.com/user-attachments/assets/901bcd4f-3900-4bbc-aab4-ca26fe47b41a" />

I have applied the same layout to the templates rendered through partials on the homepage.
