### PR TITLE
Updated docker compose web app to use env_file for environment variables.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,15 +11,8 @@ services:
 
   web:
     build: .
-    environment:
-      - REDISCLOUD_URL=${REDISCLOUD_URL}
-      - SECRET_KEY=${SECRET_KEY}
-      - DEBUG=${DEBUG}
-      - ALLOWED_HOSTS=${ALLOWED_HOSTS}
-      - DATABASE_URL=${DATABASE_URL}
-      - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
-      - SEARCHBOX_SSL_URL=${SEARCHBOX_SSL_URL}
-      - SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE}
+    env_file:
+      - .env
     command: gunicorn djangosnippets.wsgi:application -b 0.0.0.0:8000 --log-level debug -k gevent -w 2
     volumes:
       - .:/code


### PR DESCRIPTION
Updated to use `env_file` so that environment variables can be used in the container without needing to define them locally.

<img width="800" alt="Screenshot 2025-06-11 at 9 28 59 PM" src="https://github.com/user-attachments/assets/500538ae-2e32-46b6-ac90-58683886eb54" />

I set the values in the .env file because of the above README.