### PR TITLE
Remove X/Twitter as auth provider

### DIFF
--- a/djangosnippets/settings/base.py
+++ b/djangosnippets/settings/base.py
@@ -60,7 +60,6 @@ INSTALLED_APPS = (
     "allauth.socialaccount",
     "allauth.socialaccount.providers.bitbucket_oauth2",
     "allauth.socialaccount.providers.github",
-    "allauth.socialaccount.providers.twitter",
     "base",
     "cab",
     "comments_spamfighter",


### PR DESCRIPTION
This drops X/Twitter social login support. This will remove the Twitter auth provider.

This fixes issue #566.