### PR TITLE
Fix: Changed All Snippets to show count on top, #596

### DIFF
--- a/djangosnippets/templates/cab/snippet_list.html
+++ b/djangosnippets/templates/cab/snippet_list.html
@@ -2,9 +2,9 @@
 {% load core_tags %}
 {% load static %}
 {% block bodyclass %}snippet-list{% endblock %}
-{% block head_title %}All snippets{% if months %} last {{ months }} months{% endif %}{% endblock %}
+{% block head_title %} All snippets{% if months %} last {{ months }} months{% endif %}{% endblock %}
 
-{% block content_header %}All snippets{% if months %} last {{ months }} months{% endif %}{% endblock %}
+{% block content_header %} {{ hits }} snippets{% if months %} last {{ months }} months{% endif %}{% endblock %}
 
 {% block content %}
   {% if object_list %}


### PR DESCRIPTION
This resolves #596 by adding total snippets count instead of All Snippets over Snippets list.


Before - 
<img width="1919" height="1079" alt="Screenshot 2025-10-19 193542" src="https://github.com/user-attachments/assets/d6e43aa5-8c60-457d-af9f-b65ac07fc96a" />

After - 
<img width="1919" height="1079" alt="Screenshot 2025-10-19 193443" src="https://github.com/user-attachments/assets/d7b4df34-85bd-49cd-8668-52c7536ccd7b" />
