### PR TITLE
Darkened link color to darker shade of green for better visibiility

### DIFF
--- a/djangosnippets/static/scss/main.scss
+++ b/djangosnippets/static/scss/main.scss
@@ -27,7 +27,7 @@ header > .inner, footer, #main {
 }
 
 a {
-    color: $green;
+    color: #1F402E;
 
     &:hover {
         text-decoration: underline;


### PR DESCRIPTION
This change resolves #509 by changing the link from a lighter shade of green to a darker shade for more visibility in the main.scss file. Let me know if anything needs to be fixed because I am new to contributing!