### PR TITLE
Enhance the readability of the comments section in the snippet view

### DIFF
--- a/djangosnippets/templates/cab/snippet_detail.html
+++ b/djangosnippets/templates/cab/snippet_detail.html
@@ -10,7 +10,8 @@
 
 {% block content_header %}{{ object.title }}{% endblock %}
 
-{% block content %}<div class="columns large-12">
+{% block content %}
+<div class="columns large-12">
   <dl id="meta">
     <dt>Author:</dt>
     <dd><a href="{{ object.author.get_absolute_url }}">{{ object.author.username }}</a></dd>
@@ -69,9 +70,11 @@
     {% get_comment_list for object as comment_list %}
     <dl>
     {% for comment in comment_list %}
-      <dt id="c{{ comment.id }}"><a href="{{ comment.user.get_absolute_url }}">{% user_display comment.user %}</a> (on {{ comment.submit_date|date:"F j, Y" }}):</dt>
-      <dd>{{ comment.comment|safe_markdown }}
-      <p><a href="{{ comment.get_absolute_url }}">#</a></p></dd>
+      <div class="bg-gray-100 rounded-md border border-base-gray-400 mt-4">
+          <dt id="c{{ comment.id }}" class="bg-neutral-200 rounded-t-md px-2 pt-1"><a href="{{ comment.user.get_absolute_url }}">{% user_display comment.user %}</a> (on {{ comment.submit_date|date:"F j, Y" }}):</dt>
+          <dd class="px-2 pt-2">{{ comment.comment|safe_markdown }}
+          <p class="px-2"><a href="{{ comment.get_absolute_url }}">#</a></p></dd>
+      </div>
     {% endfor %}
     </dl>
     {% render_comment_form for object %}
@@ -85,4 +88,5 @@
   {{ flag_form.as_p }}
   <button type="submit">Flag this snippet</button>
 </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
This enhances the readbility of the comments in the snippet view by adding a border, margin, and a background color that will distinguish each comments.

This solves the issue #511.

Screenshot of the UI changes is shown below:

<img width="1558" height="496" alt="Screenshot 2026-01-01 at 14-44-54 djangosnippets Html Example" src="https://github.com/user-attachments/assets/03efa694-11c0-42b5-9ab6-f0cd2f300639" />

Happy New Year!  :partying_face: 
