### PR TITLE
feat: Add HTMX-powered search to snippet list (#510)

### DIFF
--- a/cab/tests/tests.py
+++ b/cab/tests/tests.py
@@ -44,6 +44,7 @@ class BaseCabTestCase(TestCase):
             author=self.user_a,
             description="A greeting\n==========",
             code='print "Hello, world"',
+            version="5.0",
         )
         self.snippet1.tags.add("hello", "world")
 
@@ -53,6 +54,7 @@ class BaseCabTestCase(TestCase):
             author=self.user_b,
             description="A farewell\n==========",
             code='print "Goodbye, world"',
+            version="5.0",
         )
         self.snippet2.tags.add("goodbye", "world")
 
@@ -62,6 +64,7 @@ class BaseCabTestCase(TestCase):
             author=self.user_a,
             description="Haxor some1z db",
             code="DROP TABLE accounts;",
+            version="5.0",
         )
         self.snippet3.tags.add("haxor")
 
@@ -613,6 +616,7 @@ class ApiTestCase(TestCase):
             author=self.user_a,
             description="A greeting\n==========",
             code='print "Hello, world"',
+            version="5.0",
         )
         self.snippet1.tags.add("hello", "world")
 
@@ -622,6 +626,7 @@ class ApiTestCase(TestCase):
             author=self.user_b,
             description="A farewell\n==========",
             code='print "Goodbye, world"',
+            version="5.0",
         )
         self.snippet2.tags.add("goodbye", "world")
 
@@ -631,6 +636,7 @@ class ApiTestCase(TestCase):
             author=self.user_a,
             description="Haxor some1z db",
             code="DROP TABLE accounts;",
+            version="5.0",
         )
         self.snippet3.tags.add("haxor")
 
@@ -695,6 +701,7 @@ class SnippetListSearchTestCase(BaseCabTestCase):
         """HTMX requests should return only the partial template."""
         response = self.client.get(
             reverse("cab_snippet_list"),
+            {"q": "django"},
             HTTP_HX_REQUEST="true",
         )
         self.assertEqual(response.status_code, 200)
@@ -709,20 +716,17 @@ class SnippetListSearchTestCase(BaseCabTestCase):
             {"q": "Hello"},
         )
         self.assertEqual(response.status_code, 200)
-        # Should find snippet1 with "Hello world" in title
         self.assertIn(self.snippet1, response.context["object_list"])
-        # Should not find snippet3 with SQL in title
         self.assertNotIn(self.snippet3, response.context["object_list"])
 
     def test_search_minimum_length(self):
         """Search with less than minimum length should return all snippets."""
         response = self.client.get(
             reverse("cab_snippet_list"),
-            {"q": "a"},  # Single character, below MIN_QUERY_LENGTH
+            {"q": "a"},
         )
         self.assertEqual(response.status_code, 200)
-        # Should return all snippets (no filtering applied)
-        self.assertEqual(len(response.context["object_list"]), 3)
+        self.assertEqual(len(list(response.context["object_list"])), 3)
 
     def test_search_no_results(self):
         """Search with no matches should return empty list."""
@@ -731,17 +735,16 @@ class SnippetListSearchTestCase(BaseCabTestCase):
             {"q": "nonexistent"},
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["object_list"]), 0)
+        self.assertEqual(len(list(response.context["object_list"])), 0)
 
     def test_htmx_search_with_query(self):
         """HTMX search request should return filtered partial."""
         response = self.client.get(
             reverse("cab_snippet_list"),
             {"q": "world"},
-            HTTP_HX_REQUEST="true",
+            headers={"HX-Request": "true"},
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "cab/partials/_snippet_table.html")
-        # Should include snippets with "world" in title
         self.assertIn(self.snippet1, response.context["object_list"])
         self.assertIn(self.snippet2, response.context["object_list"])

--- a/cab/tests/tests.py
+++ b/cab/tests/tests.py
@@ -742,7 +742,7 @@ class SnippetListSearchTestCase(BaseCabTestCase):
         response = self.client.get(
             reverse("cab_snippet_list"),
             {"q": "world"},
-            headers={"HX-Request": "true"},
+            HTTP_HX_REQUEST="true",
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "cab/partials/_snippet_table.html")

--- a/cab/views/snippets.py
+++ b/cab/views/snippets.py
@@ -18,15 +18,15 @@ from cab.utils import month_object_list, object_detail
 
 # Constants
 MIN_QUERY_LENGTH = 2
+SNIPPET_SEARCH_MIN_LENGTH = 3
 
 
 def snippet_list(request, queryset=None, **kwargs):
     if queryset is None:
         queryset = Snippet.objects.active_snippet()
 
-    SEARCH_MIN_LENGTH = 3
     q = request.GET.get("q", "").strip()
-    if q and len(q) >= SEARCH_MIN_LENGTH:
+    if q and len(q) > SNIPPET_SEARCH_MIN_LENGTH:
         if connection.vendor == "postgresql":
             search_vector = SearchVector("title", "description", "author__username")
             search_query = SearchQuery(q)

--- a/cab/views/snippets.py
+++ b/cab/views/snippets.py
@@ -5,8 +5,8 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from django.core.mail import mail_admins
+from django.db import connection
 from django.db.models import Count, Q
-from django.db.utils import NotSupportedError, ProgrammingError
 from django.http import HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -17,33 +17,30 @@ from cab.models import Language, Snippet, SnippetFlag
 from cab.utils import month_object_list, object_detail
 
 # Constants
-MIN_QUERY_LENGTH = 3
+MIN_QUERY_LENGTH = 2
 
 
 def snippet_list(request, queryset=None, **kwargs):
     if queryset is None:
         queryset = Snippet.objects.active_snippet()
 
-    # Handle search query
+    SEARCH_MIN_LENGTH = 3
     q = request.GET.get("q", "").strip()
-    if q and len(q) >= MIN_QUERY_LENGTH:
-        # Try PostgreSQL full-text search with ranking
-        try:
+    if q and len(q) >= SEARCH_MIN_LENGTH:
+        if connection.vendor == "postgresql":
             search_vector = SearchVector("title", "description", "author__username")
             search_query = SearchQuery(q)
             queryset = queryset.annotate(
                 search=search_vector,
                 rank=SearchRank(search_vector, search_query)
             ).filter(search=search_query).order_by("-rank")
-        except (NotSupportedError, ProgrammingError):
-            # Fallback to simple case-insensitive search if PostgreSQL FTS unavailable
+        else:
             queryset = queryset.filter(
                 Q(title__icontains=q) | 
                 Q(description__icontains=q) | 
                 Q(author__username__icontains=q)
             )
         
-        # Pass query to template context
         if "extra_context" not in kwargs:
             kwargs["extra_context"] = {}
         kwargs["extra_context"]["query"] = q

--- a/djangosnippets/templates/cab/partials/_snippet_table.html
+++ b/djangosnippets/templates/cab/partials/_snippet_table.html
@@ -1,0 +1,17 @@
+{% load core_tags %}
+
+<div id="snippet-table">
+    {% if object_list %}
+        
+        {% component 'snippet_list' snippet_list=object_list / %}
+        
+        {% component 'pagination' pagination_obj=pagination / %}
+
+    {% else %}
+        
+        <div class="text-center py-12">
+            <h3 class="text-xl font-medium text-gray-500">No snippets found</h3>
+        </div>
+
+    {% endif %}
+</div>

--- a/djangosnippets/templates/cab/snippet_list.html
+++ b/djangosnippets/templates/cab/snippet_list.html
@@ -1,36 +1,46 @@
 {% extends "base.html" %}
 {% load core_tags %}
 {% load static %}
+
 {% block bodyclass %}snippet-list{% endblock %}
 {% block head_title %}Snippet list{% endblock %}
 
 {% block new_content_header %}
-    <header class="bg-transparent">
-        <h1 class="my-20 text-center float-none font-header text-8xl md:text-left">{{ hits }} snippet{{ hits|pluralize }}</h1>
-        <div class="my-4 flex justify-between px-4">
-            <div></div>
-            {% component 'sorting_tabs' object_list=object_list / %}
-        </div>
-    </header>
+<header class="bg-transparent">
+
+  <h1 class="my-20 text-center float-none font-header text-8xl md:text-left">
+    {{ hits }} snippet{{ hits|pluralize }}
+  </h1>
+
+  <div class="my-4 flex flex-col md:flex-row gap-4 justify-between items-center px-4">
+
+    <form
+        hx-get="{{ request.path }}"
+        hx-target="#snippet-table"
+        hx-swap="outerHTML"
+        hx-trigger="keyup changed delay:300ms, search"
+        hx-push-url="true"
+        class="w-full md:w-auto"
+        onsubmit="return false;"
+    >
+        <input
+            type="search"
+            name="q"
+            value="{{ query|default:'' }}"
+            placeholder="Search snippets..."
+            class="w-full md:w-96 px-4 py-2 border-2 border-gray-300 rounded-lg focus:border-green-500 focus:ring-0"
+        >
+    </form>
+
+    {% component 'sorting_tabs' object_list=object_list / %}
+
+  </div>
+
+</header>
 {% endblock %}
 
 {% block content %}
-  {% if object_list %}
-    {% component 'snippet_list' snippet_list=object_list / %}
-    {% component 'pagination' pagination_obj=pagination / %}
-  {% endif %}
-{% endblock %}
+    
+    {% include "cab/partials/_snippet_table.html" %}
 
-{#{% block sidebar %}#}
-{#  <nav class="filter">#}
-{#    <h3>Filter by date</h3>#}
-{#    <ul>#}
-{#      <li{% if not months %} class="active"{% endif %}><a href="{{ request.path }}">Any time</a></li>#}
-{#      <li{% if months == 3 %} class="active"{% endif %}><a href="{{ request.path }}?months=3">3 months</a></li>#}
-{#      <li{% if months == 6 %} class="active"{% endif %}><a href="{{ request.path }}?months=6">6 months</a></li>#}
-{#      <li{% if months == 12 %} class="active"{% endif %}><a href="{{ request.path }}?months=12">1 year</a></li>#}
-{#    </ul>#}
-{#  </nav>#}
-{##}
-{#  <p><a rel="alternate" href="{% url 'cab_feed_latest' %}" type="application/atom+xml"><i class="fa fa-fw fa-rss-square"></i>Feed of latest snippets</a></p>#}
-{#{% endblock %}#}
+{% endblock %}

--- a/djangosnippets/templates/cab/snippet_list.html
+++ b/djangosnippets/templates/cab/snippet_list.html
@@ -15,21 +15,30 @@
   <div class="my-4 flex flex-col md:flex-row gap-4 justify-between items-center px-4">
 
     <form
+        method="get"
+        action="{{ request.path }}"
         hx-get="{{ request.path }}"
         hx-target="#snippet-table"
         hx-swap="outerHTML"
-        hx-trigger="keyup changed delay:300ms, search"
+        hx-trigger="input changed delay:500ms from:input[name='q'], search"
         hx-push-url="true"
         class="w-full md:w-auto"
-        onsubmit="return false;"
     >
+        <label for="search-input" class="sr-only">Search snippets</label>
         <input
+            id="search-input"
             type="search"
             name="q"
             value="{{ query|default:'' }}"
             placeholder="Search snippets..."
+            minlength="3"
             class="w-full md:w-96 px-4 py-2 border-2 border-gray-300 rounded-lg focus:border-green-500 focus:ring-0"
         >
+        {% for key, value in request.GET.items %}
+            {% if key != 'q' and key != 'page' %}
+                <input type="hidden" name="{{ key }}" value="{{ value }}">
+            {% endif %}
+        {% endfor %}
     </form>
 
     {% component 'sorting_tabs' object_list=object_list / %}

--- a/djangosnippets/templates/cab/snippet_list.html
+++ b/djangosnippets/templates/cab/snippet_list.html
@@ -22,6 +22,7 @@
         hx-swap="outerHTML"
         hx-trigger="input changed delay:500ms from:input[name='q'], search"
         hx-push-url="true"
+        hx-validate="true"
         class="w-full md:w-auto"
     >
         <label for="search-input" class="sr-only">Search snippets</label>

--- a/djangosnippets/templates/cab/snippet_list.html
+++ b/djangosnippets/templates/cab/snippet_list.html
@@ -8,9 +8,11 @@
 {% block new_content_header %}
 <header class="bg-transparent">
 
-  <h1 class="my-20 text-center float-none font-header text-8xl md:text-left">
-    {{ hits }} snippet{{ hits|pluralize }}
-  </h1>
+  <div id="snippet-count" hx-swap-oob="true">
+    <h1 class="my-20 text-center float-none font-header text-8xl md:text-left">
+      {{ hits }} snippet{{ hits|pluralize }}
+    </h1>
+  </div>
 
   <div class="my-4 flex flex-col md:flex-row gap-4 justify-between items-center px-4">
 
@@ -20,7 +22,7 @@
         hx-get="{{ request.path }}"
         hx-target="#snippet-table"
         hx-swap="outerHTML"
-        hx-trigger="input changed delay:500ms from:input[name='q'], search"
+        hx-trigger="input delay:500ms, search"
         hx-push-url="true"
         hx-validate="true"
         class="w-full md:w-auto"


### PR DESCRIPTION
## Overview
Fixes #510

This PR integrates the search functionality directly into the snippet list page using **HTMX**. This allows users to filter snippets in real-time without a full page reload, addressing the issue's request to eliminate redundant navigation to the separate search page.

## Changes
- **Frontend:**
  - moved the search bar to the snippet list header for better accessibility.
  - extracted the snippet table into a reusable partial template: `cab/partials/_snippet_table.html`.
  - added HTMX attributes (`hx-get`, `hx-target`, `hx-swap`, `hx-push-url`) to the search input.
- **Backend:**
  - updated `snippet_list` view to handle search logic directly (PostgreSQL Full-Text Search with `icontains` fallback).
  - added logic to detect `request.htmx` and render only the table partial.
- **Configuration:**
  - added `django-htmx` to `INSTALLED_APPS` and `MIDDLEWARE`.

## Key Features
- ⚡ **Real-time Filtering:** The table updates instantly as the user types.
- 🔗 **Shareable URLs:** The browser URL updates automatically (e.g., `?q=django`) so searches can be bookmarked.
- 📱 **Responsive Design:** The search bar works on both mobile and desktop layouts.
- 🛡️ **Graceful Degradation:** Standard page loads still work perfectly if JS is disabled.

## Testing
- Verified that standard (non-HTMX) requests render the full page.
- Verified that HTMX requests return only the table HTML fragment.
- Tested search queries with and without results.